### PR TITLE
Remove web-console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -46,7 +44,6 @@ GEM
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     columnize (0.9.0)
-    debug_inspector (0.0.2)
     docile (1.1.5)
     erubis (2.7.0)
     globalid (0.3.5)
@@ -118,11 +115,6 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    web-console (2.1.2)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
 
 PLATFORMS
   ruby
@@ -136,4 +128,3 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3
-  web-console (~> 2.0)


### PR DESCRIPTION
I don't want any gem unused. :hankey: not allowed
close #27 
