### PR TITLE
Set localhost as mongoid host fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ script:
   - bundle exec rake test
 services:
   - mongodb
-env:
-  - MONGODB_SOCKET=localhost:27017
 before_script:
   - sleep 15
   - mongo mydb_test --eval 'db.addUser("travis", "test");'

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,3 +1,5 @@
+<% database_socket = ENV['MONGODB_SOCKET'] || 'localhost:27017' %>
+
 development:
   # Configure available database sessions. (required)
   sessions:
@@ -9,7 +11,7 @@ development:
       # Provides the hosts the default session can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - <%= ENV['MONGODB_SOCKET'] %>
+        - <%= database_socket %>
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:
@@ -92,7 +94,7 @@ test:
     default:
       database: turniquette_test
       hosts:
-        - <%= ENV['MONGODB_SOCKET'] %>
+        - <%= database_socket %>
       options:
         read: primary
         # In the test environment we lower the retries and retry interval to


### PR DESCRIPTION
Set mongoid host to localhost unless env is set.
