### PR TITLE
Fix typo in test class name

### DIFF
--- a/test/services/registration_service_test.rb
+++ b/test/services/registration_service_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RegistrataionServiceTest < ActiveSupport::TestCase
+class RegistrationServiceTest < ActiveSupport::TestCase
   def setup
     @invitation = Invitation.create(email: 'johndoe@example.com')
     @user_data = { email: @invitation.email, password: 'my-password' }


### PR DESCRIPTION
Very dumb change. Just removing a letter that shouldn't be here:

Registrat**a**ionServiceTest --> RegistrationServiceTest
