### PR TITLE
Tracking Bundler version on Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,3 +155,6 @@ DEPENDENCIES
   rubocop
   sdoc (~> 0.4.0)
   spring
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
Since Bundler 1.10 v, bundler writes his version in Gemfie.lock
It is done due next breaking changes with Bundler 2.0

Big discussion about it: https://github.com/bundler/bundler/issues/3697
But sadly this is mandatory if we don't want a really annoying workflow (constantly changing Gemfile.lock due spring executions)
