### PR TITLE
RegistrationService Invitation/User fixes

### DIFF
--- a/app/services/registration_service.rb
+++ b/app/services/registration_service.rb
@@ -1,7 +1,10 @@
 class RegistrationService
   def from_invitation(email, invitation_token, user_data = {})
-    Invitation.find_by(email: email, token: invitation_token)
-    User.create({ email: email }.merge(user_data))
+    invitation = Invitation.find_by(email: email, token: invitation_token)
+    user = User.where(email: email).first
+    user ||= User.create!({ email: email }.merge!(user_data))
+    invitation.destroy
+    user
   rescue Mongoid::Errors::DocumentNotFound
     # find & find_by raises exception if not found
     raise InvalidInvitationError

--- a/test/services/registration_service_test.rb
+++ b/test/services/registration_service_test.rb
@@ -14,7 +14,7 @@ class RegistrationServiceTest < ActiveSupport::TestCase
   end
 
   test 'with valid invitation, creates a user' do
-    assert_equal RegistrationService.new.from_invitation(@invitation.email, @invitation.token, @user_data).class, User
+    assert_instance_of User, RegistrationService.new.from_invitation(@invitation.email, @invitation.token, @user_data)
   end
 
   test 'with valid invitation & existing user, does not create a new user' do

--- a/test/services/registration_service_test.rb
+++ b/test/services/registration_service_test.rb
@@ -17,6 +17,19 @@ class RegistrationServiceTest < ActiveSupport::TestCase
     assert_equal RegistrationService.new.from_invitation(@invitation.email, @invitation.token, @user_data).class, User
   end
 
+  test 'with valid invitation & existing user, does not create a new user' do
+    User.create(@user_data)
+    assert_no_difference 'User.count' do
+      RegistrationService.new.from_invitation(@invitation.email, @invitation.token, @user_data)
+    end
+  end
+
+  test 'with valid invitation, removes invitation' do
+    assert_difference 'Invitation.count', -1 do
+      RegistrationService.new.from_invitation(@invitation.email, @invitation.token, @user_data)
+    end
+  end
+
   test 'with NOT valid invitation token, do nothing' do
     assert_raise RegistrationService::InvalidInvitationError do
       RegistrationService.new.from_invitation(@invitation.email, 'faked-token', @user_data)


### PR DESCRIPTION
- Invitation should be deleted after User creation
- User should not be created if it exists (belongs to another Event)
